### PR TITLE
Use nulled variable in Request.get_dict() method instead of self._nullable

### DIFF
--- a/etsyv3/models/listing_request.py
+++ b/etsyv3/models/listing_request.py
@@ -39,7 +39,7 @@ class Request:
 
     def get_dict(self) -> Dict[str, Any]:
         nulled = self.get_nulled()
-        return todict(self, nullable=self._nullable)
+        return todict(self, nullable=nulled)
 
 
 class CreateDraftListingRequest(Request):

--- a/etsyv3/util/todict.py
+++ b/etsyv3/util/todict.py
@@ -1,7 +1,9 @@
 from enum import Enum
 
 
-def todict(obj, classkey=None, nullable=[]):
+def todict(obj, classkey=None, nullable=None):
+    if nullable is None:
+        nullable = []
     if isinstance(obj, dict):
         data = {}
         for (k, v) in obj.items():


### PR DESCRIPTION
Request.get_dict currently uses the class variable of self._nullable despite creating a local variable nulled from the Request.get_nulled method. This passes all nullable fields to the get_dict method and leaves them missing from the returned dict.

Currently:
```
req = UpdateListingRequest(materials=["Cotton"], tags=["tag1", "tag2"])
req.get_dict()
{'materials': None, 'tags': None}
```

With the fix:
```
req = UpdateListingRequest(materials=["Cotton"], tags=["tag1", "tag2"])
req.get_dict()
{'materials': ['Cotton'], 'tags': ['tag1', 'tag2']}
```


Currently, the default nullable parameter in util.todict is set to an empty list which is a mutable object. This doesn't currently cause any issues.
I have set it to None, then check if it's equal to None before creating it, as mentioned here:
https://docs.python.org/3/reference/compound_stmts.html#function-definitions