### PR TITLE
Implementation of updateListingProperty

### DIFF
--- a/etsyv3/etsy_api.py
+++ b/etsyv3/etsy_api.py
@@ -4,12 +4,12 @@ from typing import Callable, List
 
 import requests
 
-from etsyv3.models import ListingFile, ListingProperty, Request, UpdateListingRequest
-from etsyv3.models.listing_request import (
-    CreateDraftListingRequest,
-    UpdateListingInventoryRequest,
-    UpdateVariationImagesRequest,
-)
+from etsyv3.models import (ListingFile, ListingProperty, Request,
+                           UpdateListingRequest)
+from etsyv3.models.listing_request import (CreateDraftListingRequest,
+                                           UpdateListingInventoryRequest,
+                                           UpdateListingPropertyRequest,
+                                           UpdateVariationImagesRequest)
 
 ETSY_API_BASEURL = "https://openapi.etsy.com/v3/application/"
 
@@ -277,10 +277,10 @@ class EtsyAPI:
         shop_id: int,
         listing_id: int,
         property_id: int,
-        listing_property: ListingProperty,
+        listing_property: UpdateListingPropertyRequest,
     ):
         uri = f"{ETSY_API_BASEURL}/shops/{shop_id}/listings/{listing_id}/properties/{property_id}"
-        raise NotImplementedError
+        return self._issue_request(uri, method=Method.PUT, request_payload=listing_property)
 
     def get_listing_property(self, listing_id: int, property_id: int):
         # not in production yet

--- a/etsyv3/models/listing_request.py
+++ b/etsyv3/models/listing_request.py
@@ -281,3 +281,25 @@ class UpdateVariationImagesRequest(Request):
         for variation_image in variation_images:
             variation_image.pop("value", None)
         return UpdateVariationImagesRequest(variation_images)
+
+class UpdateListingPropertyRequest(Request):
+    nullable = []
+
+    mandatory = [
+        "value_ids",
+        "values",
+    ]
+
+    def __init__(
+        self,
+        value_ids: List[int] = None,
+        values: List[str] = None,
+        scale_id: int = None,
+    ):
+        self.value_ids = value_ids
+        self.values = values
+        self.scale_id = scale_id
+        super().__init__(
+            nullable=UpdateListingPropertyRequest.nullable,
+            mandatory=UpdateListingPropertyRequest.mandatory
+        )


### PR DESCRIPTION
Implementation of https://developer.etsy.com/documentation/reference/#operation/updateListingProperty

Example usage:
```
listing_property = {
    "property_id": 200,
    "property_values": {
        "value_ids": [1],
        "scale_id": None,
        "values": ["Black"],
    },
}

property_request = UpdateListingPropertyRequest(
    value_ids=listing_property["property_values"]["value_ids"],
    scale_id=listing_property["property_values"]["scale_id"],
    values=listing_property["property_values"]["values"],
)

etsy.update_listing_property(
    shop_id=SHOP_ID,
    listing_id=listing_id,
    property_id=listing_property["property_id"],
    listing_property=property_request,
)
```

I haven't used the ListingProperty class in listing_property. Anyone is welcome to add this in.