### PR TITLE
Implemented uploadListingImage, Removed Content-Type Header

### DIFF
--- a/etsyv3/etsy_api.py
+++ b/etsyv3/etsy_api.py
@@ -9,6 +9,7 @@ from etsyv3.models.listing_request import (
     CreateDraftListingRequest,
     UpdateListingInventoryRequest,
     UpdateVariationImagesRequest,
+    UploadListingImageRequest,
 )
 
 ETSY_API_BASEURL = "https://openapi.etsy.com/v3/application/"
@@ -98,7 +99,6 @@ class EtsyAPI:
         self.keystring = keystring
         self.session.headers = {
             "Accept": "application/json",
-            "Content-Type": "application/json",
             "x-api-key": keystring,
             "Authorization": "Bearer " + self.token,
         }
@@ -135,6 +135,12 @@ class EtsyAPI:
                 return_val = self.session.get(uri_full)
             elif method == method.PUT:
                 return_val = self.session.put(uri, json=request_payload.get_dict())
+            elif method == method.POST and isinstance(request_payload, UploadListingImageRequest):
+                return_val = self.session.post(
+                    uri,
+                    files=request_payload.image,
+                    data=request_payload.data
+                )
             elif method == method.POST:
                 return_val = self.session.post(uri, json=request_payload.get_dict())
             else:
@@ -355,8 +361,14 @@ class EtsyAPI:
         uri = f"{ETSY_API_BASEURL}/listings/{listing_id}/images"
         return self._issue_request(uri)
 
-    def upload_listing_image(self):
-        raise NotImplementedError
+    def upload_listing_image(
+        self,
+        shop_id: int,
+        listing_id: int,
+        listing_image: UploadListingImageRequest
+    ):
+        uri = f"{ETSY_API_BASEURL}/shops/{shop_id}/listings/{listing_id}/images"
+        return self._issue_request(uri, method=Method.POST, request_payload=listing_image)
 
     def get_listing_inventory(self, listing_id):
         uri = f"{ETSY_API_BASEURL}/listings/{listing_id}/inventory"

--- a/etsyv3/models/listing_request.py
+++ b/etsyv3/models/listing_request.py
@@ -281,3 +281,38 @@ class UpdateVariationImagesRequest(Request):
         for variation_image in variation_images:
             variation_image.pop("value", None)
         return UpdateVariationImagesRequest(variation_images)
+
+class UploadListingImageRequest(Request):
+    nullable = ["image"]
+    mandatory = []
+
+    def __init__(
+        self,
+        image_bytes: bytes,
+        listing_image_id=None,
+        rank=None,
+        overwrite=None,
+        is_watermarked=None,
+        alt_text=None,
+    ):
+        self.image = {
+            "image": image_bytes
+        }
+        self.data = {
+            "listing_image_id": listing_image_id,
+            "rank": rank,
+            "overwrite": overwrite,
+            "is_watermarked": is_watermarked,
+            "alt_text": alt_text,
+        }
+        
+        super().__init__(
+            nullable=UploadListingImageRequest.nullable,
+            mandatory=UploadListingImageRequest.mandatory,
+        )
+    
+    @staticmethod
+    def generate_image_bytes_from_file(file):
+        with open(file, "rb") as image:
+            image_bytes = image.read()
+        return image_bytes


### PR DESCRIPTION
Implementation of https://developer.etsy.com/documentation/reference#operation/uploadListingImage

Either an image bytes object or a listing_image_id needs to be provided, as in the documentation:

> To upload a new image, set the image file as the value for the image parameter. You can assign a previously deleted image to a listing using the deleted image's image ID in the listing_image_id parameter. When a request contains both image and listing_image_id parameter values, the endpoint uploads the image in the image parameter only. Note: When uploading a new image, data such as colors and size may return as null values due to asynchronous processing of the image. Use getListingImage endpoint to fetch these values.

I added a helper static method `generate_image_bytes_from_file(file)` to return the file bytes.

Example usage:

```
image_bytes = UploadListingImageRequest.generate_image_bytes_from_file("back.jpg")

listing_image_request = UploadListingImageRequest(
    image_bytes=image_bytes, rank=1, overwrite=True, is_watermarked=False, alt_text="Test"
)

etsy_api.upload_listing_image(
    shop_id=SHOP_ID,
    listing_id=1111111111,
    listing_image=listing_image_request
)
{'listing_id': 1111111111, 'listing_image_id': 4864172720, 'hex_code': None, 'red': None, 'green': None, 'blue': None, 'hue': None, 'saturation': None, 'brightness': None, 'is_black_and_white': None, 'creation_tsz': 1682854333, 'created_timestamp': 1682854333, 'rank': 1, 'url_75x75': 'https://i.etsystatic.com/26026723/r/il/2ac415/4864172720/il_75x75.4864172720_aof4.jpg', 'url_170x135': 'https://i.etsystatic.com/26026723/r/il/2ac415/4864172720/il_170x135.4864172720_aof4.jpg', 'url_570xN': 'https://i.etsystatic.com/26026723/r/il/2ac415/4864172720/il_570xN.4864172720_aof4.jpg', 'url_fullxfull': 'https://i.etsystatic.com/26026723/r/il/2ac415/4864172720/il_fullxfull.4864172720_aof4.jpg', 'full_height': None, 'full_width': None, 'alt_text': 'Test'}
```

I removed `"Content-Type": "application/json"` as it prevents `requests` from creating the appropriate headers when posting files, resulting in an error from the Etsy API.