### PR TITLE
Add update listing image ID

### DIFF
--- a/etsyv3/etsy_api.py
+++ b/etsyv3/etsy_api.py
@@ -16,6 +16,7 @@ from etsyv3.models.listing_request import (
     UpdateListingInventoryRequest,
     UpdateListingPropertyRequest,
     UpdateVariationImagesRequest,
+    UpdateListingImageIDRequest,
 )
 from etsyv3.models.receipt_request import (
     CreateReceiptShipmentRequest,
@@ -415,6 +416,14 @@ class EtsyAPI:
         uri = f"{ETSY_API_BASEURL}/shops/{shop_id}/listings/{listing_id}/images"
         return self._issue_request(
             uri, method=Method.POST, request_payload=listing_image
+        )
+    
+    def update_listing_image_id(
+        self, shop_id: int, listing_id: int, listing_image_id: UpdateListingImageIDRequest
+    ) -> Any:
+        uri = f"{ETSY_API_BASEURL}/shops/{shop_id}/listings/{listing_id}/images"
+        return self._issue_request(
+            uri, method=Method.POST, request_payload=listing_image_id
         )
 
     def get_listing_inventory(self, listing_id: int) -> Any:

--- a/etsyv3/models/listing_request.py
+++ b/etsyv3/models/listing_request.py
@@ -292,6 +292,30 @@ class UpdateVariationImagesRequest(Request):
             variation_image.pop("value", None)
         return UpdateVariationImagesRequest(variation_images)
 
+class UpdateListingImageIDRequest(Request):
+    nullable: List[str] = []
+    mandatory: List[str] = ["listing_image_id"]
+
+    def __init__(
+        self,
+        listing_image_id: int,
+        rank: Optional[int] = None,
+        overwrite: Optional[bool] = None,
+        is_watermarked: Optional[bool] = None,
+        alt_text: Optional[str] = None,
+    ) -> None:
+
+        self.listing_image_id = listing_image_id
+        self.rank = rank
+        self.overwrite = overwrite
+        self.is_watermarked = is_watermarked
+        self.alt_text = alt_text
+
+        super().__init__(
+            nullable=UpdateListingImageIDRequest.nullable,
+            mandatory=UpdateListingImageIDRequest.mandatory,
+        )
+
 
 class UpdateListingPropertyRequest(Request):
     nullable: List[str] = []


### PR DESCRIPTION
The Etsy API endpoint 'uploadListingImage' allows for assigning a previously uploaded listing_image_id, and re-using images is allowed.

This pull request adds a new request type, UpdateListingImageIDRequest, that takes an existing image ID instead of a file and uses that ID to update an image.

My use case was replacing an image that was identical over several hundred listings. I didn't want to upload it several hundred times though. After uploading it once and getting the listing_image_id, linking it to all the rest of the listings took the API just a few seconds. This is also advantageous for viewing performance as the image shares the same URL across listings and visits to subsequent listings can pull it from the cache.