### PR TITLE
Update etsy_api.py

### DIFF
--- a/etsyv3/etsy_api.py
+++ b/etsyv3/etsy_api.py
@@ -184,7 +184,7 @@ class EtsyAPI:
         else:
             self.refresh()
             rkw: Dict[str, Any] = kwargs
-            return self._issue_request(uri, **rkw)
+            return self._issue_request(uri, method=method, request_payload=request_payload, **rkw)
 
     def get_buyer_taxonomy_nodes(self) -> Any:
         uri = f"{ETSY_API_BASEURL}/buyer-taxonomy/nodes"


### PR DESCRIPTION
When the token is expired and _issue_request recursively calls itself after refreshing, it only passes uri and **rkw (the kwargs). It does not pass method or request_payload. So for a POST/PUT/PATCH request, after refresh it defaults to:
method=Method.GET (the default parameter), request_payload=None.