### PR TITLE
Auth headers change

### DIFF
--- a/etsyv3/etsy_api.py
+++ b/etsyv3/etsy_api.py
@@ -108,6 +108,7 @@ class EtsyAPI:
     def __init__(
         self,
         keystring: str,
+        shared_secret: str,
         token: str,
         refresh_token: str,
         expiry: datetime,
@@ -120,7 +121,7 @@ class EtsyAPI:
         self.keystring = keystring
         self.session.headers = {
             "Accept": "application/json",
-            "x-api-key": keystring,
+            "x-api-key": f"{keystring}:{shared_secret}",
             "Authorization": "Bearer " + self.token,
         }
         self.expiry = expiry

--- a/etsyv3/util/auth/auth_helper.py
+++ b/etsyv3/util/auth/auth_helper.py
@@ -11,12 +11,14 @@ class AuthHelper:
     def __init__(
         self,
         keystring: str,
+        shared_secret: str,
         redirect_uri: str,
         scopes: Optional[List[str]] = None,
         code_verifier: Optional[str] = None,
         state: Optional[str] = None,
     ):
         self.keystring = keystring
+        self.shared_secret = shared_secret
         self.redirect_url = redirect_uri
         self.scopes = scopes
         if code_verifier is None:
@@ -53,7 +55,7 @@ class AuthHelper:
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
-            "x-api-key": self.keystring,
+            "x-api-key": f"{self.keystring}:{self.shared_secret}",
         }
         self.token = self.oauth.fetch_token(
             "https://api.etsy.com/v3/public/oauth/token",


### PR DESCRIPTION
> As part of our ongoing efforts to better protect your Etsy OpenAPI application, we will require all API requests to include a shared secret starting on January 18, 2026.
> 
> To ensure uninterrupted access to the OpenAPI after this date, please update your x-api-key header to include your shared secret. The new header format is x-api-key: keystring:secret, instead of the previous x-api-key: keystring.
> 
> You can find your shared secret on the Your Apps page: https://www.etsy.com/developers/your-apps